### PR TITLE
fix: add FUNDING.yml to ls-lint ignore list

### DIFF
--- a/.github/linters/.ls-lint.yml
+++ b/.github/linters/.ls-lint.yml
@@ -2,3 +2,6 @@ ls:
   .json: snake_case
   .yaml: regex:\.?[a-z]+(-[a-z]+)*
   .yml: regex:\.?[a-z]+(-[a-z]+)*
+
+ignore:
+  - FUNDING.yml


### PR DESCRIPTION
- FUNDING.yml failed ls-lint validation due to uppercase letters
- GitHub requires FUNDING.yml to be uppercase (special config file)
- Added ignore pattern to allow FUNDING.yml while maintaining naming conventions for other YAML files
- Fixes issue #223